### PR TITLE
Fix broken code append

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,11 +15,12 @@ function pasteCloudFormationZipFile(sourceCode, sourceStack, targetStack) {
   // then place the newly indented code after `ZipFile: >` at EOF
   const stackContent = fs.readFileSync(sourceStack)
     .toString()
-    .replace(/^(\s+ZipFile: >)([\s\S])+/m, `$1\n${codeContent}`);
+    .replace(/^(\s+ZipFile: >)([\s\S])+/m, '$1\n');
 
   console.log(`Replacing code in ${targetStack} ...`);
   // write the result in `dist/`
   fs.writeFileSync(targetStack, stackContent);
+  fs.appendFileSync(targetStack, codeContent);
 }
 
 exports.replace = function replace() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-cf-custom-events",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Custom resources for CloudWatch Events in CloudFormation.",
   "author": "Evgeny Zislis <evgeny.zislis@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
Appending code using string interpretation inside a `.replace('', '<here'>)` part was a silly idea since every `$1` in the code was assigned with the value from the regexp replacement.

This pull request fixes the build process to just append the code content, by writing directly into the target file.